### PR TITLE
WIP: patch for llvmlite + python3

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,0 +1,16 @@
+from numpile import autojit
+import numpy as np
+
+@autojit
+def dot(a, b):
+    c = 0
+    n = a.shape[0]
+    for i in range(n):
+       c += a[i]*b[i]
+    return c
+
+a = np.array(range(1000,2000), dtype='int32')
+b = np.array(range(3000,4000), dtype='int32')
+
+print(dot(a,b))
+


### PR DESCRIPTION
I am trying to address #3 by rewriting autojit to work against llvmpy's successor, llvmlite.

For a first pass, I use their [compat layer](https://github.com/numba/llvmlite/tree/master/llvmlite/llvmpy), but it's not enough. The `ee` module is missing, so it's impossible to actually run the code. I did get it to generate code, or at least generate an LLVM AST, which you can see (I think?) if you turn on `DEBUG = True`:

```
$ python test.py 
================================================================================
[<numpile.TApp object at 0x112117940>, <numpile.TApp object at 0x1121178d0>] -> $c
================================================================================
{'$e': <numpile.TCon object at 0x1120efd30>, '$f': <numpile.TCon object at 0x1120efd68>, '$d': <numpile.TCon object at 0x1120efd30>, '$a': <numpile.TApp object at 0x112117940>, '$b': <numpile.TApp object at 0x1121178d0>, '$g': <numpile.TVar object at 0x112117400>, '$c': <numpile.TVar object at 0x112117400>, '$retty': <numpile.TVar object at 0x112117400>, '$h': <numpile.TVar object at 0x112117400>}
================================================================================
[(<numpile.TApp object at 0x1121174e0>, <numpile.TApp object at 0x1121175c0>), (<numpile.TVar object at 0x112117550>, <numpile.TCon object at 0x1120efd30>), (<numpile.TCon object at 0x1120efd30>, <numpile.TCon object at 0x1120efd30>), (<numpile.TVar object at 0x112117630>, <numpile.TCon object at 0x1120efd68>), (<numpile.TVar object at 0x112117470>, <numpile.TCon object at 0x1120efd30>), (<numpile.TVar object at 0x1121172e8>, <numpile.TApp object at 0x112117748>), (<numpile.TCon object at 0x1120efd30>, <numpile.TCon object at 0x1120efd30>), (<numpile.TVar object at 0x112117358>, <numpile.TApp object at 0x112117828>), (<numpile.TCon object at 0x1120efd30>, <numpile.TCon object at 0x1120efd30>), (<numpile.TVar object at 0x1121176d8>, <numpile.TVar object at 0x1121177b8>), (<numpile.TVar object at 0x112117400>, <numpile.TVar object at 0x1121177b8>), (<numpile.TVar object at 0x1121177b8>, <numpile.TVar object at 0x112117400>), (<numpile.TVar object at 0x1121177b8>, <numpile.TVar object at 0x1120facf8>)]
================================================================================
('Fun',
 {'args': [('arg', {'annotation': None, 'arg': "'a'"}),
           ('arg', {'annotation': None, 'arg': "'b'"})],
  'body': [('Assign',
            {'ref': "'c'",
             'type': <numpile.TVar object at 0x112117400>,
             'val': ('LitInt', {'n': 0})}),
           ('Assign',
            {'ref': "'n'",
             'type': <numpile.TVar object at 0x112117470>,
             'val': ('Index',
                     {'ix': ('LitInt', {'n': 0}),
                      'val': ('Prim',
                              {'args': [('Var', {'id': "'a'", 'type': None})],
                               'fn': "'shape#'"})})}),
           ('Loop',
            {'begin': ('LitInt', {'n': 0}),
             'body': [('Assign',
                       {'ref': "'c'",
                        'type': <numpile.TVar object at 0x1121177b8>,
                        'val': ('Prim',
                                {'args': [('Var',
                                           {'id': "'c'",
                                            'type': <numpile.TVar object at 0x112117400>}),
                                          ('Prim',
                                           {'args': [('Index',
                                                      {'ix': ('Var',
                                                              {'id': "'i'",
                                                               'type': <numpile.TCon object at 0x1120efd30>}),
                                                       'val': ('Var',
                                                               {'id': "'a'",
                                                                'type': <numpile.TVar object at 0x1121172e8>})}),
                                                     ('Index',
                                                      {'ix': ('Var',
                                                              {'id': "'i'",
                                                               'type': <numpile.TCon object at 0x1120efd30>}),
                                                       'val': ('Var',
                                                               {'id': "'b'",
                                                                'type': <numpile.TVar object at 0x112117358>})})],
                                            'fn': "'mult#'"})],
                                 'fn': "'add#'"})})],
             'end': ('Var',
                     {'id': "'n'",
                      'type': <numpile.TVar object at 0x112117470>}),
             'var': ('Var',
                     {'id': "'i'",
                      'type': <numpile.TCon object at 0x1120efd30>})}),
           ('Return',
            {'val': ('Var',
                     {'id': "'c'",
                      'type': <numpile.TVar object at 0x1121177b8>})})],
  'fname': "'dot'"})
================================================================================
Specialized Function: [<numpile.TApp object at 0x1120fa5f8>, <numpile.TApp object at 0x1120fa7b8>] -> Int32
Traceback (most recent call last):
  File "test.py", line 15, in <module>
    print(dot(a,b))
  File "numpile.py", line 960, in _wrapper
    llfunc = codegen(ast, specializer, retty, argtys)
  File "numpile.py", line 980, in codegen
    mod = cgen.visit(ast)
  File "numpile.py", line 802, in visit
    return getattr(self, name)(node)
  File "numpile.py", line 664, in visit_Fun
    self.start_function(func_name, module, rettype, argtypes)
  File "numpile.py", line 597, in start_function
    builder = lc.Builder.new(entry_block)
AttributeError: type object 'Builder' has no attribute 'new'
```

This is the edge of my ability here, but maybe someone with a better understanding of this stuff can take this and run with it.

Being able to JIT CPython would be very intriguing.