### PR TITLE
Remove unused itertools imports (tee, izip).

### DIFF
--- a/numpile.py
+++ b/numpile.py
@@ -9,7 +9,6 @@ import inspect
 import pprint
 import string
 import numpy as np
-from itertools import tee, izip
 
 from textwrap import dedent
 from collections import deque, defaultdict


### PR DESCRIPTION
Thanks for the great tutorial! World lost such a great Pythonista to Haskell, sigh! ;-)

Let's see if this repo is maintained, because someone really should update this to llvmlite and Python3, and that better be done in upstream...
