### PR TITLE
Add "add" and "dot" examples as standalone files.

### DIFF
--- a/example_add.py
+++ b/example_add.py
@@ -1,0 +1,12 @@
+from __future__ import print_function
+
+from numpile import autojit
+
+
+@autojit
+def add(a, b):
+    return a + b
+
+a = 3.1415926
+b = 2.7182818
+print('Result:', add(a, b))

--- a/example_dot.py
+++ b/example_dot.py
@@ -1,0 +1,19 @@
+from __future__ import print_function
+import numpy as np
+
+from numpile import autojit
+
+
+@autojit
+def dot(a, b):
+    c = 0
+    n = a.shape[0]
+    for i in range(n):
+       c += a[i] * b[i]
+    return c
+
+
+a = np.array(range(100, 200), dtype='int32')
+b = np.array(range(300, 400), dtype='int32')
+
+print('Result:', dot(a, b))


### PR DESCRIPTION
Extracted from the notebook file/blog post. Can be run with python
executable directly, e.g.:

python example_dot.py

Note that the range of values in example_dot.py was reduced to avoid
32-bit integer overflow.