### PR TITLE
minor cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,23 @@ Usage
 -----
 
 ```python
+import numpy as np
 from numpile import autojit
+
 
 @autojit
 def dot(a, b):
     c = 0
     n = a.shape[0]
     for i in range(n):
-       c += a[i]*b[i]
+        c += a[i] * b[i]
     return c
 
-a = np.array(range(1000,2000), dtype='int32')
-b = np.array(range(3000,4000), dtype='int32')
 
-print dot(a,b)
+a = np.arange(100, 200, dtype='int32')
+b = np.arange(300, 400, dtype='int32')
+result = dot(a, b) 
+print(result)
 ```
 
 License

--- a/example_add.py
+++ b/example_add.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from numpile import autojit
 
 
@@ -7,6 +5,8 @@ from numpile import autojit
 def add(a, b):
     return a + b
 
+
 a = 3.1415926
 b = 2.7182818
-print('Result:', add(a, b))
+result = add(a, b)
+print(result)

--- a/example_dot.py
+++ b/example_dot.py
@@ -1,6 +1,4 @@
-from __future__ import print_function
 import numpy as np
-
 from numpile import autojit
 
 
@@ -9,11 +7,11 @@ def dot(a, b):
     c = 0
     n = a.shape[0]
     for i in range(n):
-       c += a[i] * b[i]
+        c += a[i] * b[i]
     return c
 
 
-a = np.array(range(100, 200), dtype='int32')
-b = np.array(range(300, 400), dtype='int32')
-
-print('Result:', dot(a, b))
+a = np.arange(100, 200, dtype="int32")
+b = np.arange(300, 400, dtype="int32")
+result = dot(a, b)
+print(result)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-llvmpy==0.11.1
+llvmlite
 numpy>=1.7.0  


### PR DESCRIPTION
Some minor cleanup.

Fixes the code example in the README (now works in Python 3), and requirements.txt (list llvmlite instead of llvmpy).