### PR TITLE
Add missing import and fix pyflakes warnings

### DIFF
--- a/numpile.py
+++ b/numpile.py
@@ -1,6 +1,7 @@
 # LLVM based numeric specializer in 1000 lines.
 from __future__ import print_function
 
+from functools import reduce
 import sys
 import ast
 import types
@@ -221,7 +222,6 @@ class TypeInfer(object):
             return self.generic_visit(node)
 
     def visit_Fun(self, node):
-        arity = len(node.args)
         self.argtys = [self.fresh() for v in node.args]
         self.retty = TVar("$retty")
         for (arg, ty) in zip(node.args, self.argtys):
@@ -425,7 +425,6 @@ class PythonVisitor(ast.NodeVisitor):
     def visit_Call(self, node):
         name = self.visit(node.func)
         args = list(map(self.visit, node.args))
-        keywords = list(map(self.visit, node.keywords))
         return App(name, args)
 
     def visit_BinOp(self, node):
@@ -436,8 +435,6 @@ class PythonVisitor(ast.NodeVisitor):
         return Prim(opname, [a, b])
 
     def visit_Assign(self, node):
-        targets = node.targets
-
         assert len(node.targets) == 1
         var = node.targets[0].id
         val = self.visit(node.value)


### PR DESCRIPTION
```
$ pyflakes numpile.py 
numpile.py:179: undefined name 'reduce'
numpile.py:224: local variable 'arity' is assigned to but never used
numpile.py:370: undefined name 'InfiniteType'
numpile.py:428: local variable 'keywords' is assigned to but never used
numpile.py:439: local variable 'targets' is assigned to but never used
```

This PR fixes the bug with `reduce` on Python 3 to work on both Python 2 and 3 https://python-future.org/compatible_idioms.html#reduce
and removes the unused variables.

For the bug with `InfiniteType` I wasn't  sure what to do, so I opened a separate issue: #10

@sdiehl - Thank you for this! Will read and study the code and notebook in the next days...